### PR TITLE
fix: 청년 정책 지역구에서 서울 제거

### DIFF
--- a/src/features/Policy/filters.ts
+++ b/src/features/Policy/filters.ts
@@ -1,7 +1,6 @@
 import type { FilterGroup } from "@/components/shared/Fillter";
 export const CATEGORY_LIST = ["일자리", "주거", "복지.문화", "참여.권리", "교육", "분류없음"];
 export const koreaRegions = [
-  "서울",
   "경기",
   "부산",
   "인천",


### PR DESCRIPTION
## 🔗 관련 이슈 번호

## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업한 파일
- src/features/Policy/filters.ts

## 📝 작업한 내용
-지역구 필터 중 '서울'에 해당하는 데이터가 존재하지 않음을 확인.
'서울시'로 분리
